### PR TITLE
DeepFreeze - RPM compatibility fixes

### DIFF
--- a/Source/PortraitStats.cs
+++ b/Source/PortraitStats.cs
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 using System.Collections.Generic;
 using System.Reflection;
+using System.Linq;
 using UnityEngine;
 
 namespace PortraitStats
@@ -115,7 +116,17 @@ namespace PortraitStats
 
 			if (reload)
 			{
-				foreach (Kerbal k in KerbalGUIManager.ActiveCrew)
+                List<string> crewtodelete = new List<string>();
+                foreach (KeyValuePair<string, KerbalTrait> crew in currentCrew)
+                {
+                    Kerbal fndkerbal = KerbalGUIManager.ActiveCrew.Where(x => x.name == crew.Key).FirstOrDefault();
+                    if (fndkerbal != null)
+                        continue;
+
+                    crewtodelete.Add(crew.Key);
+                }
+                crewtodelete.ForEach(id => currentCrew.Remove(id));
+                foreach (Kerbal k in KerbalGUIManager.ActiveCrew)
 				{
 					if (currentCrew.ContainsKey(k.name))
 						continue;
@@ -155,19 +166,22 @@ namespace PortraitStats
 
 		private void drawLabels()
 		{
-			int crewCount = KerbalGUIManager.ActiveCrew.Count;
+            if (FlightGlobals.ActiveVessel.isEVA)
+                return;
+
+            switch (CameraManager.Instance.currentCameraMode)
+            {
+                case CameraManager.CameraMode.Map:
+                case CameraManager.CameraMode.Internal:
+                case CameraManager.CameraMode.IVA:
+                    return;
+            }
+
+            int crewCount = KerbalGUIManager.ActiveCrew.Count;
 
 			if (crewCount <= 0)
 				return;
-
-			switch (CameraManager.Instance.currentCameraMode)
-			{
-				case CameraManager.CameraMode.Map:
-				case CameraManager.CameraMode.Internal:
-				case CameraManager.CameraMode.IVA:
-					return;
-			}
-
+            		
 			Color old = GUI.color;
 			bool drawTooltip = false;
 			bool drawTraitTooltip = false;


### PR DESCRIPTION
There is a compatibility issue with DeepFreeze and RPM transparent pods due to the way they manipulate the KerbalGUIManager that portrait stats does not cater for.
PortraitStats does not check for kerbals that have been removed from KerbalGUIManager and update it's internal dictionary.
- Fixes compatibility with DeepFreeze and RPM transparent pods by checking if crew have been removed from the KerbalGUIManager and removing them from the kerbalstats dictionary.

There seems to be an issue when a kerbal goes EVA where the KerbalGUIManager has a reference to the WRONG kerbal which portraitstats displays.
![2015-08-26 06_07_46-kerbal space program](https://cloud.githubusercontent.com/assets/9981382/9480455/8bc8bcf0-4bc6-11e5-8106-dba810cc741a.png)
- Removes portraitstats when in EVA mode as it incorrectly shows (there is no portrait camera anyway) and it displays for the wrong crewmember (seems to be a KSP bug).
